### PR TITLE
Fix of csv for semicolon

### DIFF
--- a/src/logic/export/to_csv.py
+++ b/src/logic/export/to_csv.py
@@ -1,5 +1,5 @@
-import io
 import csv
+import io
 
 from sqlalchemy.orm import selectinload
 from sqlmodel import select

--- a/src/logic/export/to_csv.py
+++ b/src/logic/export/to_csv.py
@@ -1,3 +1,6 @@
+import io
+import csv
+
 from sqlalchemy.orm import selectinload
 from sqlmodel import select
 
@@ -26,21 +29,13 @@ async def query_for_csv_export(reporting_schema_id: str, session) -> list[models
 def generate_csv_schema(schema_categories: list[models_schema.SchemaCategory]) -> str:
     """Generate a CSV string of the database contents."""
 
-    separator = ";"
-    # Specify the fields
-    format_ = separator.join(
-        [
-            "{class}",
-            "{name}",
-            "{source}",
-            "{quantity}",
-            "{unit}",
-            "{description}",
-        ]
-    )
+    csv_io = io.StringIO("", newline="")
+    fields = ["class", "name", "source", "quantity", "unit", "description"]
+
+    wrapper = csv.DictWriter(csv_io, fieldnames=fields, delimiter=";", quoting=csv.QUOTE_NONNUMERIC)
+
     # Generate the header row
-    header = format_.replace("{", "").replace("}", "")
-    row_list = [header]
+    wrapper.writeheader()
     # Extract field values from SchemaElements
     for category in schema_categories:
         # ?: Create extra line for category here?
@@ -53,6 +48,5 @@ def generate_csv_schema(schema_categories: list[models_schema.SchemaCategory]) -
                 "unit": element.unit,
                 "description": element.description,
             }
-            row_list.append(format_.format(**values))
-    csv_str = "\n".join(row_list)
-    return csv_str
+            wrapper.writerow(values)
+    return csv_io.getvalue()

--- a/src/models/source.py
+++ b/src/models/source.py
@@ -49,8 +49,21 @@ class ProjectSource(SQLModel, table=True):
 
                     # reader: [{"col1_name": "row_val", "col2_name":..}, {...}]
                     if self.type == ProjectSourceType.CSV.value:
-                        file_data = StringIO(raw_data.decode())
-                        reader = pandas.read_csv(file_data).replace({np.nan: None}).to_dict("records")
+                        try:
+                            data = raw_data.decode("utf-8")
+                        except UnicodeDecodeError:
+                            data = raw_data.decode("cp1252")
+                        header = data[: data.index("\n")]
+                        if header.count(";") >= 2:
+                            sep = ";"
+                            dec = ","
+                        else:
+                            sep = ","
+                            dec = "."
+                        file_data = StringIO(data)
+                        reader = (
+                            pandas.read_csv(file_data, sep=sep, decimal=dec).replace({np.nan: None}).to_dict("records")
+                        )
 
                     elif self.type == ProjectSourceType.XLSX.value:
                         reader = pandas.read_excel(raw_data).replace({np.nan: None}).to_dict("records")

--- a/src/schema/export.py
+++ b/src/schema/export.py
@@ -44,4 +44,4 @@ async def export_reporting_schema_mutation(info: Info, reporting_schema_id: str,
     else:
         raise NotImplementedError
 
-    return str(base64.b64encode(data.encode("utf-8")), "utf-8")
+    return str(base64.b64encode(data.encode("utf-8-sig")), "utf-8")

--- a/tests/integration/test_schema_element_endpoint.py
+++ b/tests/integration/test_schema_element_endpoint.py
@@ -115,6 +115,11 @@ async def test_create_schema_element_from_source(
         "quantity",
         "source",
     }
+    src1 = data["addSchemaElementFromSource"][1]
+    del src1['schemaCategory']
+    del src1['source']
+    
+    assert src1 == {'name': 'Wall 3', 'unit': 'M3', 'description': 'my wall 3', 'quantity': 456.789}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_schema_element_endpoint.py
+++ b/tests/integration/test_schema_element_endpoint.py
@@ -116,10 +116,10 @@ async def test_create_schema_element_from_source(
         "source",
     }
     src1 = data["addSchemaElementFromSource"][1]
-    del src1['schemaCategory']
-    del src1['source']
-    
-    assert src1 == {'name': 'Wall 3', 'unit': 'M3', 'description': 'my wall 3', 'quantity': 456.789}
+    del src1["schemaCategory"]
+    del src1["source"]
+
+    assert src1 == {"name": "Wall 3", "unit": "M3", "description": "my wall 3", "quantity": 456.789}
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_schema_export_endpoint.py
+++ b/tests/integration/test_schema_export_endpoint.py
@@ -102,9 +102,9 @@ async def test_csv_export(client, db, reporting_schemas, schema_elements, schema
     data = response.json()
     assert isinstance(data["data"]["exportReportingSchema"], str)
     csv_rows = base64.b64decode(data["data"]["exportReportingSchema"])
-    csv_rows = csv_rows.decode("utf-8").split("\n")
+    csv_rows = csv_rows.decode("utf-8-sig").split("\n")
 
-    assert csv_rows[0] == "class;name;source;quantity;unit;description"
+    assert csv_rows[0].rstrip() == '"class";"name";"source";"quantity";"unit";"description"'.rstrip()
     element = schema_elements[0]
     expected_data = ";".join(
         [
@@ -119,7 +119,7 @@ async def test_csv_export(client, db, reporting_schemas, schema_elements, schema
             )
         ]
     )
-    assert csv_rows[1] == expected_data
+    assert csv_rows[1].replace('"', '').rstrip() == expected_data
 
 
 @pytest.mark.asyncio
@@ -156,7 +156,7 @@ async def test_lcax_export(
     assert data.get("errors") is None
     assert isinstance(data["data"]["exportReportingSchema"], str)
 
-    lcax_data = base64.b64decode(data["data"]["exportReportingSchema"]).decode("utf-8")
+    lcax_data = base64.b64decode(data["data"]["exportReportingSchema"]).decode("utf-8-sig")
     assert lcax_data
 
     lcax_project = LCAxProject(**json.loads(lcax_data))

--- a/tests/integration/test_schema_export_endpoint.py
+++ b/tests/integration/test_schema_export_endpoint.py
@@ -119,7 +119,7 @@ async def test_csv_export(client, db, reporting_schemas, schema_elements, schema
             )
         ]
     )
-    assert csv_rows[1].replace('"', '').rstrip() == expected_data
+    assert csv_rows[1].replace('"', "").rstrip() == expected_data
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_csv_format.py
+++ b/tests/unit/test_csv_format.py
@@ -1,9 +1,10 @@
+from unittest.mock import PropertyMock
+
 import pytest
 
-from unittest.mock import PropertyMock
+from logic.export.to_csv import generate_csv_schema
 from models.schema_category import SchemaCategory
 from models.schema_element import SchemaElement
-from logic.export.to_csv import generate_csv_schema
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_csv_format.py
+++ b/tests/unit/test_csv_format.py
@@ -5,6 +5,7 @@ from models.schema_category import SchemaCategory
 from models.schema_element import SchemaElement
 from logic.export.to_csv import generate_csv_schema
 
+
 @pytest.mark.asyncio
 async def test_csv_element(category: SchemaCategory, mocker):
     """Test that SchemaElement is correctly written to CSV."""
@@ -12,11 +13,13 @@ async def test_csv_element(category: SchemaCategory, mocker):
     m = mocker.patch("models.schema_element.SchemaElement.source", new_callable=PropertyMock)
     m.return_value = False
 
-    expected_csv = '''\
+    expected_csv = """\
 "class";"name";"source";"quantity";"unit";"description"
 "211 | Udvendige vægelementer";"Wall";"Typed in";2500.0;"m3";"A 5th century oak palisade wall."
-'''.replace('\r\n', '\n')
+""".replace(
+        "\r\n", "\n"
+    )
 
-    generated_csv = generate_csv_schema([category]).replace('\r\n', '\n')
+    generated_csv = generate_csv_schema([category]).replace("\r\n", "\n")
 
     assert expected_csv == generated_csv

--- a/tests/unit/test_csv_format.py
+++ b/tests/unit/test_csv_format.py
@@ -1,27 +1,22 @@
 import pytest
 
+from unittest.mock import PropertyMock
 from models.schema_category import SchemaCategory
 from models.schema_element import SchemaElement
-
+from logic.export.to_csv import generate_csv_schema
 
 @pytest.mark.asyncio
-async def test_csv_element(category: SchemaCategory):
+async def test_csv_element(category: SchemaCategory, mocker):
     """Test that SchemaElement is correctly written to CSV."""
-    element = category.elements[0]
-    attributes = (
-        "name",
-        "quantity",
-        "unit",
-        "description",
-        "result",
-        # "schema_category",    # FIXME: read name/id
-        # "commits",    # FIXME
-        # "tasks",      # FIXME
-        # "source",     # FIXME
-    )
-    # TODO: check what order of columns makes sense
-    row_contents = ";".join([str(getattr(element, attr)) or "-" for attr in attributes])
-    header = ";".join(attributes)
-    expected_csv = "\n".join([header, row_contents])
 
-    assert True  # FIXME
+    m = mocker.patch("models.schema_element.SchemaElement.source", new_callable=PropertyMock)
+    m.return_value = False
+
+    expected_csv = '''\
+"class";"name";"source";"quantity";"unit";"description"
+"211 | Udvendige vægelementer";"Wall";"Typed in";2500.0;"m3";"A 5th century oak palisade wall."
+'''.replace('\r\n', '\n')
+
+    generated_csv = generate_csv_schema([category]).replace('\r\n', '\n')
+
+    assert expected_csv == generated_csv


### PR DESCRIPTION
Changes:
* Fixed `generate_csv_schema()` to use the `csv` module instead of ad-hoc generation
* Fixed `ProjectSource::data()` to better guess the character set and separator character
* Fixed `export_reporting_schema_mutation()` to emit UTF-8 with BOM for safer character set recognizion
* Added/Fixed relevant unit tests and integration tests for above changes